### PR TITLE
add non us specific 'meter' spelling support for buffer unit.

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ module.exports = function(feature, radius, units) {
       radius = radius / 111.12;
     break;
     case 'meters':
+    case 'metres':
       radius = radius / 111120.0;
     break;
     case 'degrees':


### PR DESCRIPTION
Added ability to specify buffer units in US and non-US spelling of 'meter' (i.e. 'metre').