### PR TITLE
Updating jsts dependency for react-native compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,8 @@ var bufferOp = function(feature, radius) {
   var reader = new jsts.io.GeoJSONReader();
   var geom = reader.read(JSON.stringify(feature.geometry));
   var buffered = geom.buffer(radius);
-  var parser = new jsts.io.GeoJSONParser();
-  buffered = parser.write(buffered);
+  var writer = new jsts.io.GeoJSONWriter();
+  buffered = writer.write(buffered)
 
   return {
     type: 'Feature',

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "geojson-normalize": "0.0.0",
-    "jsts": "^0.15.0",
+    "jsts": "^1.0.3",
     "turf-combine": "^1.0.2",
     "turf-featurecollection": "^1.0.1",
     "turf-polygon": "^1.0.3"


### PR DESCRIPTION
Hi,

The current version of jsts that this package uses exports a global (`jsts`) unexplicitly (i.g., not `window.jsts`)

This breaks the package in (react native's) strict mode.

I updated the dependency and used the GeoJSONWriter (the GeoJSONParser is gone in the latest version of jsts).

When shrinkwrapping I got weird results (probably because I am using npm@3?) It adds all dependencies (including devDependencies) to the shrinkwrap, and marks jsts as @latest, I guess the idea is that it locks it at a specific version, so I guess we will have to update the `npm-shrinkwrap.json` manually.

Thanks for turf, I use it with a lot of pleasure.