### PR TITLE
Simplify/improve example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,8 @@ var pt = {
 var unit = 'miles';
 
 var buffered = turf.buffer(pt, 500, unit);
-var result = turf.featurecollection([buffered, pt]);
 
-//=result
+//=buffered
 ```
 
 


### PR DESCRIPTION
It's not clear why the translation to a feature collection was made in the example. 

The rendered result was `null`, which made this feature look broken.  I think the old example was broken because the output was expected to be a FeatureCollection, but since the input is a Feature.Point, the output is a Feature.Polygon.